### PR TITLE
feat: caching using redis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,10 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/ndungutse/project_tracker/ProjectTrackerApplication.java
+++ b/src/main/java/com/ndungutse/project_tracker/ProjectTrackerApplication.java
@@ -2,11 +2,35 @@ package com.ndungutse.project_tracker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @SpringBootApplication
+@EnableCaching
+@EnableJpaRepositories(basePackages = "com.ndungutse.project_tracker.repository")
 public class ProjectTrackerApplication {
 
+    @Bean
+    public RedisCacheConfiguration cacheConfiguration() {
+        RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()));
+        return RedisCacheConfiguration
+                .defaultCacheConfig(Thread.currentThread().getContextClassLoader())
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair
+                                .fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(java.time.Duration.ofHours(1)) // Set default TTL for cache
+                .disableCachingNullValues();
+    }
+
     public static void main(String[] args) {
+        System.setProperty("spring.devtools.restart.enabled", "false");
         SpringApplication.run(ProjectTrackerApplication.class, args);
     }
 

--- a/src/main/java/com/ndungutse/project_tracker/ProjectTrackerApplication.java
+++ b/src/main/java/com/ndungutse/project_tracker/ProjectTrackerApplication.java
@@ -30,6 +30,7 @@ public class ProjectTrackerApplication {
     }
 
     public static void main(String[] args) {
+        // Disable for testing caching
         System.setProperty("spring.devtools.restart.enabled", "false");
         SpringApplication.run(ProjectTrackerApplication.class, args);
     }

--- a/src/main/java/com/ndungutse/project_tracker/config/AppConfig.java
+++ b/src/main/java/com/ndungutse/project_tracker/config/AppConfig.java
@@ -4,9 +4,14 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 @Configuration
 public class AppConfig {
@@ -21,5 +26,12 @@ public class AppConfig {
         objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         objectMapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         return objectMapper;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig())
+                .build();
     }
 }

--- a/src/main/java/com/ndungutse/project_tracker/controller/ProjectController.java
+++ b/src/main/java/com/ndungutse/project_tracker/controller/ProjectController.java
@@ -69,9 +69,8 @@ public class ProjectController {
         @GetMapping("/{id}")
         public ResponseEntity<ProjectDTO> getProjectById(
                         @Parameter(description = "ID of the project to retrieve", required = true) @PathVariable Long id) {
-                Optional<ProjectDTO> project = projectService.getById(id);
-                return project.map(value -> new ResponseEntity<>(value, HttpStatus.OK))
-                                .orElseGet(() -> new ResponseEntity<>(HttpStatus.NOT_FOUND));
+                ProjectDTO project = projectService.getById(id);
+                return new ResponseEntity<>(project, HttpStatus.OK);
         }
 
         // Update a project

--- a/src/main/java/com/ndungutse/project_tracker/dto/ProjectDTO.java
+++ b/src/main/java/com/ndungutse/project_tracker/dto/ProjectDTO.java
@@ -1,5 +1,6 @@
 package com.ndungutse.project_tracker.dto;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class ProjectDTO {
+public class ProjectDTO implements Serializable {
     private Long id;
     private String name;
     private String description;

--- a/src/main/java/com/ndungutse/project_tracker/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ndungutse/project_tracker/exception/GlobalExceptionHandler.java
@@ -37,6 +37,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, String>> handleAllExceptions(Exception ex) {
         System.out.println(ex.getMessage());
+        System.out.println(ex.toString());
         return new ResponseEntity<>(Map.of("message", ex.getMessage()), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/ndungutse/project_tracker/repository/ProjectRepository.java
+++ b/src/main/java/com/ndungutse/project_tracker/repository/ProjectRepository.java
@@ -2,12 +2,14 @@ package com.ndungutse.project_tracker.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.redis.core.RedisHash;
 import org.springframework.stereotype.Repository;
 
 import com.ndungutse.project_tracker.dto.projection.ProjectIdNameStatusDto;
 import com.ndungutse.project_tracker.model.Project;
 
 @Repository
+@RedisHash("project")
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     Page<ProjectIdNameStatusDto> findAllBy(org.springframework.data.domain.Pageable pageable);
 

--- a/src/main/java/com/ndungutse/project_tracker/repository/ProjectRepository.java
+++ b/src/main/java/com/ndungutse/project_tracker/repository/ProjectRepository.java
@@ -1,11 +1,11 @@
 package com.ndungutse.project_tracker.repository;
 
-import com.ndungutse.project_tracker.dto.projection.ProjectIdNameStatusDto;
-import com.ndungutse.project_tracker.model.Project;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import com.ndungutse.project_tracker.dto.projection.ProjectIdNameStatusDto;
+import com.ndungutse.project_tracker.model.Project;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {

--- a/src/main/java/com/ndungutse/project_tracker/service/ProjectService.java
+++ b/src/main/java/com/ndungutse/project_tracker/service/ProjectService.java
@@ -57,6 +57,7 @@ public class ProjectService {
     public Page<ProjectDTO> getAll(
             int page,
             int size) {
+
         Pageable pageable = PageRequest.of(page, size);
         Page<Project> projectPage = projectRepository.findAll(pageable);
         return projectMapper.toPageDto(projectPage);

--- a/src/main/java/com/ndungutse/project_tracker/service/TaskService.java
+++ b/src/main/java/com/ndungutse/project_tracker/service/TaskService.java
@@ -54,7 +54,7 @@ public class TaskService {
         Task newTask = taskMapper.toEntity(taskDTO);
 
         // Get the project entity
-        Project project = projectMapper.toEntity(projectService.getById(taskDTO.getProjectId()).get());
+        Project project = projectMapper.toEntity(projectService.getById(taskDTO.getProjectId()));
 
         // Get the assigned user entity if provided
         User assignedUser = null;
@@ -139,7 +139,7 @@ public class TaskService {
                 projectService.exists(updatedTaskDTO.getProjectId())) {
 
             Optional<Project> projectOpt = Optional.ofNullable(projectMapper
-                    .toEntity(projectService.getById(updatedTaskDTO.getProjectId()).get()));
+                    .toEntity(projectService.getById(updatedTaskDTO.getProjectId())));
 
             projectOpt.ifPresent(existingTask::setProject);
         }


### PR DESCRIPTION
## Description

This pull request introduces caching functionality to the project tracker application using Redis, refactors several methods for improved clarity and performance, and updates the `ProjectDTO` class to implement `Serializable`. The most important changes include enabling Redis caching, modifying service methods to utilize caching annotations, and updating the `ProjectDTO` class for serialization compatibility.

### Caching Implementation

* Added the `spring-boot-starter-data-redis` dependency to enable Redis integration.
* Enabled caching with `@EnableCaching`, configured Redis cache settings, and set a default TTL for cache entries.
*  Added a `CacheManager` bean using `RedisCacheManager` to manage cache operations.

### Service Layer Updates for Caching
*  Added caching annotations (`@Cacheable`, `@CachePut`, and `@CacheEvict`) to methods for caching project data by ID and paginated results.
* Refactored methods to remove redundant `Optional` wrapping when retrieving projects, aligning with the updated `ProjectService` methods. 

### Serialization Compatibility

* Updated the `ProjectDTO` class to implement `Serializable`, ensuring compatibility with Redis caching.